### PR TITLE
Add get_version_info tool + CI workflow (v0.2.2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+# Cancel superseded runs on the same ref (push or PR) so we don't waste
+# minutes when commits land in rapid succession.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: pytest (${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install package + test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install pytest pytest-asyncio
+
+      - name: Run unit tests (L2)
+        run: python -m pytest tests/test_tools.py -v
+
+      - name: Run security tests
+        run: python -m pytest tests/test_security.py -v
+
+  ci-all-green:
+    name: ci-all-green
+    needs: [test]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Verify required jobs all succeeded
+        run: |
+          if [[ "${{ needs.test.result }}" != "success" ]]; then
+            echo "FAIL: test matrix did not all succeed (result=${{ needs.test.result }})"
+            exit 1
+          fi
+          echo "All required CI jobs passed."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to `pota-mcp` are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.2] — 2026-05-15
+
+### Added
+- New tool `get_version_info` — returns `{service_name, service_version, spec_version}`
+  for fleet identity attestation. Lets agents detect version drift across MCP
+  deployments without going outside the protocol. Tracks
+  [IONIS-AI/ionis-devel#49](https://github.com/IONIS-AI/ionis-devel/issues/49)
+  (fleet rollout).
+- `__spec_version__` constant in package `__init__.py`, pinned to `pota-api-v1`.
+- L2 unit tests POTA-L2-046 through POTA-L2-050 covering the new tool.
+- `.github/workflows/ci.yml` — PR-gating CI workflow (py3.10-3.13 matrix,
+  unit + security tests, ci-all-green aggregator).
+
+### Changed
+- `__init__.py` modernized to mirror the `adif-mcp`/`solar-mcp` pattern
+  (`Final` types, explicit `PackageNotFoundError` handling).
+
+## [0.2.1] — Previous release
+- See git history for changes prior to the changelog being introduced.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ pip install pota-mcp
 | `pota_scheduled` | Upcoming scheduled activations |
 | `pota_location_parks` | All parks in a state/province/country |
 | `pota_nearby_parks` | Find parks near a point — great for 2-fer planning |
+| `get_version_info` | Service version + upstream spec version (fleet identity attestation) |
 
 ## Quick Start
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pota-mcp"
-version = "0.2.1"
+version = "0.2.2"
 description = "MCP server for Parks on the Air — park lookup, activator/hunter stats, spots"
 readme = "README.md"
 license = {text = "GPL-3.0-or-later"}

--- a/src/pota_mcp/__init__.py
+++ b/src/pota_mcp/__init__.py
@@ -2,9 +2,18 @@
 
 from __future__ import annotations
 
-try:
-    from importlib.metadata import version
+from importlib.metadata import PackageNotFoundError, version
+from typing import Final
 
-    __version__ = version("pota-mcp")
-except Exception:
-    __version__ = "0.0.0-dev"
+try:
+    _pkg_version = version("pota-mcp")
+except PackageNotFoundError:  # local dev / editable installs without dist metadata
+    _pkg_version = "0.0.0-dev"
+
+__version__: Final[str] = _pkg_version
+
+# Upstream data spec the server is bound to. Pinned to the POTA public API
+# version we consume — bump this when pota.app publishes a new API contract.
+# Reported by the get_version_info tool so agents can detect fleet drift
+# without going outside the MCP protocol.
+__spec_version__: Final[str] = "pota-api-v1"

--- a/src/pota_mcp/server.py
+++ b/src/pota_mcp/server.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from fastmcp import FastMCP
 
-from . import __version__
+from . import __spec_version__, __version__
 from .client import POTAClient
 
 mcp = FastMCP(
@@ -34,6 +34,32 @@ def _get_client() -> POTAClient:
 # ---------------------------------------------------------------------------
 # Tools
 # ---------------------------------------------------------------------------
+
+
+def _version_info_payload() -> dict[str, Any]:
+    """Build the version info envelope. Pulled into a helper so tests can
+    call it directly without going through the FastMCP wrapper."""
+    return {
+        "service_name": "pota-mcp",
+        "service_version": __version__,
+        "spec_version": __spec_version__,
+    }
+
+
+@mcp.tool()
+def get_version_info() -> dict[str, Any]:
+    """Get pota-mcp service version and upstream spec version.
+
+    Returns the running PyPI version of pota-mcp and the POTA API
+    revision currently in use. Use this to confirm fleet alignment
+    across MCP deployments — agents can compare service_version and
+    spec_version across servers to detect drift without going outside
+    the MCP protocol.
+
+    Returns:
+        service_name, service_version (PyPI), and spec_version (POTA API).
+    """
+    return _version_info_payload()
 
 
 @mcp.tool()

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -287,3 +287,48 @@ class TestEdgeCases:
         """POTA-L2-045: Very close points → near-zero distance."""
         dist = POTAClient._haversine(43.617, -115.993, 43.6171, -115.9931)
         assert dist < 0.1  # Less than 100 meters
+
+
+# ---------------------------------------------------------------------------
+# POTA-L2-046..050: get_version_info — fleet identity attestation
+# ---------------------------------------------------------------------------
+
+
+class TestGetVersionInfo:
+    """Tracks IONIS-AI/ionis-devel#49 — fleet get_version_info convention."""
+
+    def test_returns_service_name(self):
+        """POTA-L2-046: payload includes service_name = 'pota-mcp'."""
+        from pota_mcp.server import _version_info_payload
+
+        assert _version_info_payload()["service_name"] == "pota-mcp"
+
+    def test_returns_service_version(self):
+        """POTA-L2-047: service_version matches package __version__."""
+        from pota_mcp import __version__
+        from pota_mcp.server import _version_info_payload
+
+        assert _version_info_payload()["service_version"] == __version__
+
+    def test_returns_spec_version(self):
+        """POTA-L2-048: spec_version pins the POTA API revision."""
+        from pota_mcp.server import _version_info_payload
+
+        assert _version_info_payload()["spec_version"] == "pota-api-v1"
+
+    def test_payload_keys_are_required_set(self):
+        """POTA-L2-049: payload has exactly the required keys (no extras yet)."""
+        from pota_mcp.server import _version_info_payload
+
+        result = _version_info_payload()
+        required = {"service_name", "service_version", "spec_version"}
+        assert required.issubset(set(result.keys()))
+
+    def test_all_values_are_strings(self):
+        """POTA-L2-050: all returned values are strings (JSON-safe envelope)."""
+        from pota_mcp.server import _version_info_payload
+
+        result = _version_info_payload()
+        for k in ("service_name", "service_version", "spec_version"):
+            assert isinstance(result[k], str), f"{k} should be str, got {type(result[k])}"
+            assert result[k], f"{k} should be non-empty"


### PR DESCRIPTION
## Summary

Fleet rollout per [IONIS-AI/ionis-devel#49](https://github.com/IONIS-AI/ionis-devel/issues/49) — second server after solar-mcp (exemplar). Same diff shape as [qso-graph/solar-mcp#1](https://github.com/qso-graph/solar-mcp/pull/1).

## Response envelope

```json
{
  "service_name":    "pota-mcp",
  "service_version": "0.2.2",
  "spec_version":    "pota-api-v1"
}
```

## Changes

- `src/pota_mcp/__init__.py` — add `__spec_version__` `Final` constant
- `src/pota_mcp/server.py` — add `get_version_info` tool + `_version_info_payload` helper
- `tests/test_tools.py` — `TestGetVersionInfo` (POTA-L2-046 .. POTA-L2-050)
- `README.md` — tool added to tools table
- `CHANGELOG.md` — new file
- `.github/workflows/ci.yml` — new PR-gating CI (matches solar-mcp template)
- `pyproject.toml` — 0.2.1 → 0.2.2

## Test plan

- [x] 45 existing + 5 new unit tests pass (`pytest tests/test_tools.py`)
- [x] 6 security tests pass
- [ ] CI matrix green